### PR TITLE
[FE][Feat] 팝오버 구현

### DIFF
--- a/FE/src/assets/styles/GlobalStyle.tsx
+++ b/FE/src/assets/styles/GlobalStyle.tsx
@@ -148,6 +148,7 @@ const GlobalStyle = createGlobalStyle`
   }
   a:link,
   a:visited {
+    color: inherit;
     text-decoration: none;
   }
   ul,

--- a/FE/src/components/Header/index.tsx
+++ b/FE/src/components/Header/index.tsx
@@ -24,7 +24,7 @@ const Header = () => {
           <Image
             url='https://avatars.githubusercontent.com/u/93566353?v=4'
             alt='Khan'
-            size={IMAGE_SIZE.LARGE}
+            size={IMAGE_SIZE.MEDIUM}
           />
         </S.LogoutMenuButton>
         {isLogoutMenuOpen && (

--- a/FE/src/components/IssueTable/Issue/Issue.style.ts
+++ b/FE/src/components/IssueTable/Issue/Issue.style.ts
@@ -35,11 +35,9 @@ export const IssueTitleWrapper = styled.div`
   align-items: center;
   margin-bottom: 8px;
 
-  svg {
-    path {
-      fill: #C7EBFF;
-      stroke: #007AFF;
-    }
+  svg path {
+    fill: ${({ theme }) => theme.colors.lightBlue};
+    stroke: ${({ theme }) => theme.colors.blue};
   }
 `;
 

--- a/FE/src/components/IssueTable/PopOver/AuthorPopOver.stories.tsx
+++ b/FE/src/components/IssueTable/PopOver/AuthorPopOver.stories.tsx
@@ -1,0 +1,24 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+
+import AuthorPopOver from '@components/IssueTable/PopOver/AuthorPopOver';
+import * as S from '@components/common/PopOver/PopOver.style';
+
+export default {
+  title: 'Component/IssueTable/AuthorPopOver',
+  component: AuthorPopOver,
+} as ComponentMeta<typeof AuthorPopOver>;
+
+export const Default: ComponentStory<typeof AuthorPopOver> = () => {
+  const element = document.getElementById('root') as HTMLElement;
+  element.style.position = 'relative';
+
+  return (
+    <BrowserRouter>
+      <S.StoryWrapper>
+        Element
+        <AuthorPopOver />
+      </S.StoryWrapper>
+    </BrowserRouter>
+  );
+};

--- a/FE/src/components/IssueTable/PopOver/AuthorPopOver.tsx
+++ b/FE/src/components/IssueTable/PopOver/AuthorPopOver.tsx
@@ -1,0 +1,24 @@
+import * as S from '@components/IssueTable/PopOver/PopOver.style';
+import Image from '@components/common/Image';
+import { IMAGE_SIZE } from '@components/common/Image/constants';
+import PopOver from '@components/common/PopOver';
+
+const AuthorPopOver = () => {
+  return (
+    <PopOver>
+      <S.ContentsWrapper>
+        <Image
+          url='https://avatars.githubusercontent.com/u/62706988?v=4'
+          alt='Jamie'
+          size={IMAGE_SIZE.LARGE}
+        />
+        <S.UserInformation>
+          <S.UserId>mina-gwak</S.UserId>
+          <S.UserName>Jamie</S.UserName>
+        </S.UserInformation>
+      </S.ContentsWrapper>
+    </PopOver>
+  )
+}
+
+export default AuthorPopOver;

--- a/FE/src/components/IssueTable/PopOver/IssuePopOver.stories.tsx
+++ b/FE/src/components/IssueTable/PopOver/IssuePopOver.stories.tsx
@@ -1,0 +1,29 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+
+import IssuePopOver from '@components/IssueTable/PopOver/IssuePopOver';
+import * as S from '@components/common/PopOver/PopOver.style';
+import { issueDummyData } from '@data';
+import { IssueListType } from '@type/issueType';
+
+export default {
+  title: 'Component/IssueTable/IssuePopOver',
+  component: IssuePopOver,
+  args: {
+    ...issueDummyData[1],
+  }
+} as ComponentMeta<typeof IssuePopOver>;
+
+export const Default: ComponentStory<typeof IssuePopOver> = (args: IssueListType) => {
+  const element = document.getElementById('root') as HTMLElement;
+  element.style.position = 'relative';
+
+  return (
+    <BrowserRouter>
+      <S.StoryWrapper>
+        Element
+        <IssuePopOver {...args} />
+      </S.StoryWrapper>
+    </BrowserRouter>
+  );
+};

--- a/FE/src/components/IssueTable/PopOver/IssuePopOver.tsx
+++ b/FE/src/components/IssueTable/PopOver/IssuePopOver.tsx
@@ -1,0 +1,71 @@
+import * as S from '@components/IssueTable/PopOver/PopOver.style';
+import Icon from '@components/common/Icon';
+import { ICON_NAME } from '@components/common/Icon/constants';
+import Image from '@components/common/Image';
+import { IMAGE_SIZE } from '@components/common/Image/constants';
+import Label from '@components/common/Label';
+import PopOver from '@components/common/PopOver';
+import { IssueListType } from '@type/issueType';
+
+const MAX_LABEL = 3;
+const USER = 'Jamie';
+
+const IssuePopOver = ({ title, labels, num, assignees, author, isOpen, time }: IssueListType) => {
+  const iconName = isOpen ? ICON_NAME.ALERT_CIRCLE : ICON_NAME.ARCHIVE;
+
+  // TODO: 유저의 네임값 가져와서 비교
+  const isAuthor = author.name === USER;
+  const isAssignee = assignees.some(({ name }) => name === USER);
+
+  const userDescription = () => {
+    if (isAuthor && isAssignee) return 'You are assigned and opened';
+    else if (isAuthor) return 'You are opened';
+    else if (isAssignee) return 'You are assigned';
+  };
+
+  return (
+    <PopOver>
+      <S.Wrapper {...{ isOpen }}>
+        <S.ContentsWrapper>
+          <S.Date>Jun 18</S.Date>
+          <S.ContentsContainer>
+            <Icon {...{ iconName }} />
+            <div>
+              <S.IssueLink to='/issue-list'>
+                <S.Title>{title}</S.Title>
+                <S.IssueNumber>#{num}</S.IssueNumber>
+              </S.IssueLink>
+              <S.IssueContents>
+                Hercle, victrix regius! gratis absolutio! rem Est bassus armarium, cesaris. Ecce, nixus! Nunquam fallere boreas.
+              </S.IssueContents>
+              <S.LabelList>
+                {labels.map((label) => (
+                  <li>
+                    <Label {...label} />
+                  </li>
+                ))}
+                {labels.length > MAX_LABEL && (
+                  <li>
+                    <S.MoreLabel>+ more</S.MoreLabel>
+                  </li>
+                )}
+              </S.LabelList>
+            </div>
+          </S.ContentsContainer>
+        </S.ContentsWrapper>
+        {(isAuthor || isAssignee) && (
+          <S.UserWrapper>
+            <Image
+              url={author.imgUrl}
+              alt={author.name}
+              size={IMAGE_SIZE.SMALL}
+            />
+            <S.UserDescription>{userDescription()}</S.UserDescription>
+          </S.UserWrapper>
+        )}
+      </S.Wrapper>
+    </PopOver>
+  );
+};
+
+export default IssuePopOver;

--- a/FE/src/components/IssueTable/PopOver/IssuePopOver.tsx
+++ b/FE/src/components/IssueTable/PopOver/IssuePopOver.tsx
@@ -6,6 +6,7 @@ import { IMAGE_SIZE } from '@components/common/Image/constants';
 import Label from '@components/common/Label';
 import PopOver from '@components/common/PopOver';
 import { IssueListType } from '@type/issueType';
+import { getDate } from '@utils/date';
 
 const MAX_LABEL = 3;
 const USER = 'Jamie';
@@ -27,11 +28,11 @@ const IssuePopOver = ({ title, labels, num, assignees, author, isOpen, time }: I
     <PopOver>
       <S.Wrapper {...{ isOpen }}>
         <S.ContentsWrapper>
-          <S.Date>Jun 18</S.Date>
+          <S.Date>{getDate(time)}</S.Date>
           <S.ContentsContainer>
             <Icon {...{ iconName }} />
             <div>
-              <S.IssueLink to='/issue-list'>
+              <S.IssueLink to='이슈 상세 페이지'>
                 <S.Title>{title}</S.Title>
                 <S.IssueNumber>#{num}</S.IssueNumber>
               </S.IssueLink>

--- a/FE/src/components/IssueTable/PopOver/PopOver.style.ts
+++ b/FE/src/components/IssueTable/PopOver/PopOver.style.ts
@@ -1,0 +1,111 @@
+import { Link } from 'react-router-dom';
+import styled, { css } from 'styled-components';
+
+interface StyledIconProps {
+  isOpen: boolean;
+}
+
+const smallTextStyle = css`
+  color: ${({ theme }) => theme.colors.grey2};
+  font-size: ${({ theme }) => theme.fontSizes.xSmall};
+`;
+
+const iconStyle = css<StyledIconProps>`
+  ${({ isOpen }) =>
+    isOpen &&
+    css`
+      path {
+        fill: ${({ theme }) => theme.colors.lightBlue};
+        stroke: ${({ theme }) => theme.colors.blue};
+      }
+    `}
+
+  ${({ isOpen }) =>
+    !isOpen &&
+    css`
+      path {
+        fill: ${({ theme }) => theme.colors.lightPurple};
+        stroke: ${({ theme }) => theme.colors.purple};
+      }
+    `}
+`;
+
+export const Wrapper = styled.div<StyledIconProps>`
+  & > div:not(:last-child) {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.grey4};
+  }
+  
+  * {
+    font-size: 14px;
+  }
+
+  svg {
+    position: relative;
+    top: 3px;
+
+    ${iconStyle}
+  }
+`;
+
+export const ContentsWrapper = styled.div`
+  padding: 16px;
+`;
+
+/* Issue PopOver */
+
+export const ContentsContainer = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+export const Date = styled.span`
+  display: block;
+  color: ${({ theme }) => theme.colors.grey2};
+  margin-bottom: 4px;
+`;
+
+export const IssueLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 4px;
+
+  &:hover * {
+    color: ${({ theme }) => theme.colors.blue};
+  }
+`;
+
+export const Title = styled.h3``;
+
+export const IssueNumber = styled.span`
+  color: ${({ theme }) => theme.colors.grey2};
+`;
+
+export const IssueContents = styled.p`
+  color: ${({ theme }) => theme.colors.grey2};
+  margin-bottom: 12px;
+`;
+
+export const LabelList = styled.ul`
+  display: flex;
+  gap: 4px;
+
+  * {
+    cursor: default;
+  }
+`;
+
+export const MoreLabel = styled.span`
+  ${smallTextStyle};
+`;
+
+export const UserWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+`;
+
+export const UserDescription = styled.p`
+  ${smallTextStyle};
+`;

--- a/FE/src/components/IssueTable/PopOver/PopOver.style.ts
+++ b/FE/src/components/IssueTable/PopOver/PopOver.style.ts
@@ -109,3 +109,17 @@ export const UserWrapper = styled.div`
 export const UserDescription = styled.p`
   ${smallTextStyle};
 `;
+
+/* Author PopOver */
+
+export const UserInformation = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+`;
+
+export const UserId = styled.h3``;
+
+export const UserName = styled.span`
+  color: ${({ theme }) => theme.colors.grey2};
+`;

--- a/FE/src/components/common/Icon/Icon.style.ts
+++ b/FE/src/components/common/Icon/Icon.style.ts
@@ -29,6 +29,7 @@ const sizeStyles = css<StyledIconProps>`
 
 export const Icon = (iconName: IconsType) => {
   return styled(Icons[iconName])<StyledIconProps>`
+    flex-shrink: 0;
     ${sizeStyles}
   `;
 };

--- a/FE/src/components/common/Image/Image.stories.tsx
+++ b/FE/src/components/common/Image/Image.stories.tsx
@@ -1,20 +1,21 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import Image, { ImagePropsType } from '@components/common/Image';
-import { IMAGE_NAME } from '@components/common/Image/constants';
+import { IMAGE_SIZE } from '@components/common/Image/constants';
 
 export default {
   title: 'Common/Image',
   component: Image,
   args: {
-    imageName: IMAGE_NAME.LARGE_LOGO,
+    url: 'https://avatars.githubusercontent.com/u/62706988?v=4',
+    alt: 'Profile',
   },
   argTypes: {
-    imageName: {
+    size: {
       control: {
         type: 'radio',
       },
-      options: [...Object.values(IMAGE_NAME)],
+      options: [...Object.values(IMAGE_SIZE)],
     },
   },
 } as ComponentMeta<typeof Image>;

--- a/FE/src/components/common/Image/Image.style.ts
+++ b/FE/src/components/common/Image/Image.style.ts
@@ -18,11 +18,21 @@ export const sizeStyles = css<StyledImageProps>`
     `}
 
   ${({ size }) =>
-    size === IMAGE_SIZE.LARGE &&
+    size === IMAGE_SIZE.MEDIUM &&
     css`
       display: block;
       width: 2.75rem;
       height: 2.75rem;
+      border: 1px solid ${({ theme }) => theme.colors.grey4};
+      border-radius: 50%;
+    `}
+
+  ${({ size }) =>
+    size === IMAGE_SIZE.LARGE &&
+    css`
+      display: block;
+      width: 4rem;
+      height: 4rem;
       border: 1px solid ${({ theme }) => theme.colors.grey4};
       border-radius: 50%;
     `}

--- a/FE/src/components/common/Image/constants.ts
+++ b/FE/src/components/common/Image/constants.ts
@@ -5,5 +5,6 @@ export const IMAGE_NAME = {
 
 export const IMAGE_SIZE = {
   SMALL: 'SMALL',
+  MEDIUM: 'MEDIUM',
   LARGE: 'LARGE',
 } as const;

--- a/FE/src/components/common/Label/Label.style.ts
+++ b/FE/src/components/common/Label/Label.style.ts
@@ -6,7 +6,7 @@ interface LabelTagType {
 }
 
 export const LabelTag = styled.span<LabelTagType>`
-  font-size: ${({ theme }) => theme.fontSizes.small};
+  font-size: ${({ theme }) => theme.fontSizes.xSmall};
   color: ${({ textColor }) => textColor};
   background-color: ${({ backgroundColor }) => backgroundColor};
   border-radius: 30px;

--- a/FE/src/components/common/PopOver/PopOver.stories.tsx
+++ b/FE/src/components/common/PopOver/PopOver.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import PopOver, { PopOverPropsType } from '@components/common/PopOver';
+import * as S from '@components/common/PopOver/PopOver.style';
+
+export default {
+  title: 'Common/PopOver',
+  component: PopOver,
+} as ComponentMeta<typeof PopOver>;
+
+export const Default: ComponentStory<typeof PopOver> = (args: PopOverPropsType) => {
+  const element = document.getElementById('root') as HTMLElement;
+  element.style.position = 'relative';
+
+  return (
+    <S.StoryWrapper>
+      Element
+      <PopOver {...args} />
+    </S.StoryWrapper>
+  );
+};

--- a/FE/src/components/common/PopOver/PopOver.style.ts
+++ b/FE/src/components/common/PopOver/PopOver.style.ts
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  position: absolute;
+  bottom: calc(100% + 30px);
+  left: 50%;
+  width: 360px;
+  min-height: 170px;
+  border: 1px solid ${({ theme }) => theme.colors.grey4};
+  border-radius: 6px;
+  background-color: ${({ theme }) => theme.colors.white};
+  transform: translateX(-10%);
+  padding: 16px;
+  
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    width: 0;
+    height: 0;
+    border: solid transparent;
+  }
+  
+  &::after {
+    left: 24px;
+    border-width: 16px;
+    border-top-color: ${({ theme }) => theme.colors.white};
+  }
+
+  &::before {
+    left: 23px;
+    border-width: 17px;
+    border-top-color: ${({ theme }) => theme.colors.grey4};
+  }
+`;
+
+export const StoryWrapper = styled.div`
+  position: absolute;
+  top: 250px;
+  left: 50px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 200px;
+  height: 100px;
+  background-color: ${({ theme }) => theme.colors.grey5};
+`;

--- a/FE/src/components/common/PopOver/PopOver.style.ts
+++ b/FE/src/components/common/PopOver/PopOver.style.ts
@@ -5,12 +5,11 @@ export const Wrapper = styled.div`
   bottom: calc(100% + 30px);
   left: 50%;
   width: 360px;
-  min-height: 170px;
+  min-height: 100px;
   border: 1px solid ${({ theme }) => theme.colors.grey4};
   border-radius: 6px;
   background-color: ${({ theme }) => theme.colors.white};
   transform: translateX(-10%);
-  padding: 16px;
   
   &::before,
   &::after {

--- a/FE/src/components/common/PopOver/index.tsx
+++ b/FE/src/components/common/PopOver/index.tsx
@@ -1,0 +1,11 @@
+import * as S from '@components/common/PopOver/PopOver.style';
+
+export interface PopOverPropsType {
+  children?: JSX.Element;
+}
+
+const PopOver = ({ children }: PopOverPropsType) => {
+  return <S.Wrapper>{children}</S.Wrapper>;
+};
+
+export default PopOver;

--- a/FE/src/data/issueDummyData.ts
+++ b/FE/src/data/issueDummyData.ts
@@ -16,6 +16,7 @@ export const issueDummyData: IssueListType[] = [
       name: 'Khan',
       imgUrl: 'https://avatars.githubusercontent.com/u/93566353?v=4',
     },
+    isOpen: true,
     time: new Date(1655712214955),
   },
   {
@@ -33,6 +34,7 @@ export const issueDummyData: IssueListType[] = [
       name: 'Jamie',
       imgUrl: 'https://avatars.githubusercontent.com/u/62706988?v=4',
     },
+    isOpen: false,
     time: new Date(1655712114955),
   },
 ];

--- a/FE/src/type/issueType.ts
+++ b/FE/src/type/issueType.ts
@@ -24,5 +24,6 @@ export interface IssueListType {
   milestone: MilestoneType;
   assignees: MemberType[];
   author: MemberType;
+  isOpen: boolean;
   time: Date;
 }

--- a/FE/src/utils/date.ts
+++ b/FE/src/utils/date.ts
@@ -8,3 +8,10 @@ export const calcTwoTimeDifference = (updatedDateTime: Date) => {
   else if (result < 1440) return `${(result / 60).toFixed()}시간 ${(result % 60).toFixed()}분전`;
   return `${(result / 1440).toFixed()}일 전`;
 }
+
+const month = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export const getDate = (registeredDate: Date) => {
+  const date = new Date(registeredDate);
+  return `${month[date.getMonth()]} ${date.getDate()}`;
+}


### PR DESCRIPTION
## 📃 Description

- 재사용 가능한 팝오버 컴포넌트 구현
- 위의 컴포넌트를 사용해 이슈, 작성자 팝오버 컴포넌트 구현

## 📸 Screenshot

<img width="432" alt="이슈 팝오버" src="https://user-images.githubusercontent.com/62706988/175018485-ac1b114c-181f-4581-9cd4-18e0f0248553.png" />

<img width="445" alt="작성자 팝오버" src="https://user-images.githubusercontent.com/62706988/175018263-466985da-7732-4694-a865-9a8a181eb8c6.png" />