### PR TITLE
쿼리 최적화 & 페이징 구현

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -33,7 +33,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+ 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/BE/src/main/java/com/codesquad/issueTracker/comment/domain/Comment.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/comment/domain/Comment.java
@@ -63,4 +63,8 @@ public class Comment {
     public void editContent(String content) {
         this.content = content;
     }
+
+    public void removeRelationWithIssue() {
+        issue.deleteComment(this);
+    }
 }

--- a/BE/src/main/java/com/codesquad/issueTracker/common/infrastructure/aspect/LogAspect.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/common/infrastructure/aspect/LogAspect.java
@@ -3,6 +3,7 @@ package com.codesquad.issueTracker.common.infrastructure.aspect;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -21,8 +22,9 @@ public class LogAspect {
         stopWatch.start();
         Object proceed = joinPoint.proceed();
         stopWatch.stop();
+        MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+        log.info("method position : {}", signature.getMethod());
         log.info(stopWatch.prettyPrint());
-
         return proceed;
     }
 }

--- a/BE/src/main/java/com/codesquad/issueTracker/common/infrastructure/aspect/LogAspect.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/common/infrastructure/aspect/LogAspect.java
@@ -1,0 +1,28 @@
+package com.codesquad.issueTracker.common.infrastructure.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Component
+@Aspect
+public class LogAspect {
+    
+    private static final Logger log = LoggerFactory.getLogger(LogAspect.class);
+
+    @Around("@annotation(LogExecutionTime)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+
+        stopWatch.start();
+        Object proceed = joinPoint.proceed();
+        stopWatch.stop();
+        log.info(stopWatch.prettyPrint());
+
+        return proceed;
+    }
+}

--- a/BE/src/main/java/com/codesquad/issueTracker/common/infrastructure/aspect/LogExecutionTime.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/common/infrastructure/aspect/LogExecutionTime.java
@@ -1,0 +1,11 @@
+package com.codesquad.issueTracker.common.infrastructure.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogExecutionTime {
+}

--- a/BE/src/main/java/com/codesquad/issueTracker/issue/application/IssueService.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/issue/application/IssueService.java
@@ -4,11 +4,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.codesquad.issueTracker.comment.domain.Comment;
 import com.codesquad.issueTracker.comment.domain.CommentRepository;
+import com.codesquad.issueTracker.common.infrastructure.aspect.LogExecutionTime;
 import com.codesquad.issueTracker.issue.application.dto.CommentOutline;
 import com.codesquad.issueTracker.issue.application.dto.FilterCondition;
 import com.codesquad.issueTracker.issue.application.dto.IssueCoverResponse;
@@ -46,10 +48,11 @@ public class IssueService {
     private final MilestoneRepository milestoneRepository;
     private final CommentRepository commentRepository;
 
+    @LogExecutionTime
     @Transactional(readOnly = true)
-    public IssueCoversResponse findIssuesByCondition(String query, Long userId) {
+    public IssueCoversResponse findIssuesByCondition(String query, Long userId, Pageable pageable) {
         FilterCondition condition = queryParser.makeFilterCondition(query);
-        List<Issue> issues = issueRepository.search(condition, userId);
+        List<Issue> issues = issueRepository.search(condition, userId, pageable);
         long allIssueCount = issueRepository.count();
 
         List<IssueCoverResponse> result = issues.stream()

--- a/BE/src/main/java/com/codesquad/issueTracker/issue/application/dto/IssueCoverResponse.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/issue/application/dto/IssueCoverResponse.java
@@ -43,10 +43,10 @@ public class IssueCoverResponse {
 
         this.title = issue.getTitle();
         this.issueId = issue.getId();
-        this.writer = issue.getUser().getName();
-        this.writerImage = issue.getUser().getImage();
+        this.writer = issue.getUsername();
+        this.writerImage = issue.getUserImage();
         this.modificationTime = issue.getModificationTime();
-        this.milestoneName = issue.getMilestone().getName();
+        this.milestoneName = issue.getMilestoneName();
         this.opened = issue.isOpened();
     }
 }

--- a/BE/src/main/java/com/codesquad/issueTracker/issue/application/dto/IssueCoversResponse.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/issue/application/dto/IssueCoversResponse.java
@@ -8,13 +8,13 @@ import lombok.Getter;
 public class IssueCoversResponse {
 
     private List<IssueCoverResponse> issueCoverResponses;
-    private int openIssueCount;
-    private int closeIssueCount;
+    private long openIssueCount;
+    private long closeIssueCount;
     private long labelCount;
     private long milestoneCount;
 
     public IssueCoversResponse(
-        List<IssueCoverResponse> issueCoverResponses, int openIssueCount, int closeIssueCount, long labelCount,
+        List<IssueCoverResponse> issueCoverResponses, long openIssueCount, long closeIssueCount, long labelCount,
         long milestoneCount) {
         this.issueCoverResponses = issueCoverResponses;
         this.openIssueCount = openIssueCount;

--- a/BE/src/main/java/com/codesquad/issueTracker/issue/domain/Issue.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/issue/domain/Issue.java
@@ -3,6 +3,7 @@ package com.codesquad.issueTracker.issue.domain;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.CascadeType;
@@ -154,5 +155,20 @@ public class Issue {
 
     public void deleteComment(Comment comment) {
         comments.remove(comment);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Issue issue = (Issue)o;
+        return Objects.equals(getId(), issue.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/BE/src/main/java/com/codesquad/issueTracker/issue/domain/Issue.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/issue/domain/Issue.java
@@ -139,4 +139,20 @@ public class Issue {
         attachedLabels.clear();
         attachedLabel(labels);
     }
+
+    public String getUsername() {
+        return user.getName();
+    }
+
+    public String getUserImage() {
+        return user.getImage();
+    }
+
+    public String getMilestoneName() {
+        return milestone.getName();
+    }
+
+    public void deleteComment(Comment comment) {
+        comments.remove(comment);
+    }
 }

--- a/BE/src/main/java/com/codesquad/issueTracker/issue/domain/repository/IssueRepositoryCustom.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/issue/domain/repository/IssueRepositoryCustom.java
@@ -2,9 +2,11 @@ package com.codesquad.issueTracker.issue.domain.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+
 import com.codesquad.issueTracker.issue.application.dto.FilterCondition;
 import com.codesquad.issueTracker.issue.domain.Issue;
 
 public interface IssueRepositoryCustom {
-    List<Issue> search(FilterCondition condition, Long userId);
+    List<Issue> search(FilterCondition condition, Long userId, Pageable pageable);
 }

--- a/BE/src/main/java/com/codesquad/issueTracker/issue/domain/repository/IssueRepositoryCustomImpl.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/issue/domain/repository/IssueRepositoryCustomImpl.java
@@ -45,10 +45,10 @@ public class IssueRepositoryCustomImpl implements IssueRepositoryCustom {
 
         return queryFactory.selectFrom(issue)
             .join(issue.user, user).fetchJoin()
+            .leftJoin(issue.milestone, milestone).fetchJoin()
             .leftJoin(issue.assignedIssues, assignedIssue)
             .leftJoin(assignedIssue.user, assignedUser)
             .leftJoin(issue.comments, comment)
-            .leftJoin(issue.milestone, milestone).fetchJoin()
             .leftJoin(issue.attachedLabels, attachedLabel)
             .leftJoin(attachedLabel.label, label)
 
@@ -74,13 +74,19 @@ public class IssueRepositoryCustomImpl implements IssueRepositoryCustom {
 
     private Predicate addMainCondition(MainFilter condition, Long userId,
         QUser assignedUser) {
+        if (condition.equals(MainFilter.OPEN)) {
+            return issue.isOpened.eq(true);
+        }
+        if (condition.equals(MainFilter.CLOSE)) {
+            return issue.isOpened.eq(false);
+        }
         if (condition.equals(MainFilter.WRITE_BY_ME)) {
             return issue.user.id.eq(userId);
         }
         if (condition.equals(MainFilter.ADD_COMMENT_BY_ME)) {
             return comment.user.id.eq(userId);
         }
-        // TODO : 만약 이 필터이며, subfilter에서 Assign_me도 할당된다면?
+        // TODO : 만약 이 필터이며, subfilter에서 Assign_me도 할당된다면 어떻게 처리해야할 지?
         if (condition.equals(MainFilter.ASSIGNED_ME)) {
             return assignedUser.id.eq(userId);
         }

--- a/BE/src/main/java/com/codesquad/issueTracker/issue/domain/repository/IssueRepositoryCustomImpl.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/issue/domain/repository/IssueRepositoryCustomImpl.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.MultiValueMap;
 
@@ -36,9 +37,8 @@ public class IssueRepositoryCustomImpl implements IssueRepositoryCustom {
     public IssueRepositoryCustomImpl(EntityManager entityManager) {
         this.queryFactory = new JPAQueryFactory(entityManager);
     }
-
     @Override
-    public List<Issue> search(FilterCondition condition, Long userId) {
+    public List<Issue> search(FilterCondition condition, Long userId, Pageable pageable) {
 
         QUser assignedUser = new QUser("assignedUser");
         MultiValueMap<String, SubFilterDetail> subFilters = condition.getSubFilters();
@@ -57,6 +57,8 @@ public class IssueRepositoryCustomImpl implements IssueRepositoryCustom {
                 matching(milestone.name, subFilters.get("MILESTONE")),
                 matching(label.name, subFilters.get("LABEL")),
                 matching(assignedUser.name, subFilters.get("ASSIGNEE")))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
             .distinct()
             .fetch();
     }

--- a/BE/src/main/java/com/codesquad/issueTracker/issue/presentation/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issueTracker/issue/presentation/IssueController.java
@@ -5,6 +5,8 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -41,8 +43,9 @@ public class IssueController {
     private final IssueService issueService;
 
     @GetMapping
-    public ResponseEntity<IssueCoversResponse> findIssues(@RequestParam String query, @RequestAttribute Long userId) {
-        return ResponseEntity.ok(issueService.findIssuesByCondition(query, userId));
+    public ResponseEntity<IssueCoversResponse> findIssues(
+        @PageableDefault Pageable pageable, @RequestParam String query, @RequestAttribute Long userId) {
+        return ResponseEntity.ok(issueService.findIssuesByCondition(query, userId, pageable));
     }
 
     @GetMapping("/{issueId}/popUp")

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
 
   sql:
     init:
-      mode: always
+      mode: never
 
 jwt:
   token:

--- a/BE/src/main/resources/data.sql
+++ b/BE/src/main/resources/data.sql
@@ -26,7 +26,7 @@ insert into issue (title, content, is_opened, written_time, modification_time, u
 ('title1', 'content1', true, null, null, 1, 1),
 ('title2', 'content2', true, null, null, 2, 2),
 ('title3', 'content3', true, null, null, 2, 3),
-('title4', 'content4', true, null, null, 3, 4),
+('title4', 'content4', false, null, null, 3, 4),
 ('title5', 'content5', true, null, null, 1, 2),
 ('title6', 'content6', true, null, null, 5, 3),
 ('title7', 'content7', true, null, null, 7, 2);

--- a/BE/src/main/resources/static/docs/index.html
+++ b/BE/src/main/resources/static/docs/index.html
@@ -967,7 +967,7 @@ Host: localhost:8080</code></pre>
 <h4 id="show-Issue-List_http_request"><a class="link" href="#show-Issue-List_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/issues?query=is:open HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/issues?page=0&amp;size=10&amp;query=is:open HTTP/1.1
 Authorization: Bearer testToken
 Accept: */*
 Host: localhost:8080</code></pre>
@@ -988,6 +988,14 @@ Host: localhost:8080</code></pre>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">원하는 페이지, 기본 0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">원하는 사이즈, 기본 10</p></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>query</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">is:open(열린 이슈), is:close(닫힌 이슈), is:write_by_me(내가 작성한 이슈), is:assigned_me(나에게 할당된 이슈), is:add_comment_by_me(내가 댓글을 남긴 이슈), label:xx(라벨 필터 적용), assignee:yy(assignee 필터 적용), milestone:zz(마일스톤 필터 적용)</p></td>
@@ -1025,7 +1033,7 @@ Content-Length: 721
     "issueId" : 1,
     "writer" : "user1",
     "writerImage" : "image1",
-    "modificationTime" : "2022-07-17T14:48:29.929226",
+    "modificationTime" : "2022-07-18T20:34:27.114319",
     "milestoneName" : "milestone1",
     "opened" : true
   } ],
@@ -1188,7 +1196,7 @@ Content-Length: 156
 {
   "title" : "BE Lucid가 작성한 issue",
   "content" : "내용은 이러하다",
-  "writtenTime" : "2022-07-17T14:48:29.835836",
+  "writtenTime" : "2022-07-18T20:34:27.081229",
   "assignedMe" : true
 }</code></pre>
 </div>
@@ -1410,7 +1418,7 @@ Content-Length: 946
   "issueId" : 1,
   "title" : "title1",
   "content" : "content1",
-  "writtenTime" : "2022-07-17T14:48:29.459354",
+  "writtenTime" : "2022-07-18T20:34:26.628148",
   "writerOutline" : {
     "optionName" : "user1",
     "imageUrl" : "image1"
@@ -1423,12 +1431,12 @@ Content-Length: 946
     "imageUrl" : "image1"
   } ],
   "labels" : [ {
-    "labelName" : "Lucid",
-    "colorCode" : "#008672",
-    "textColor" : "white"
-  }, {
     "labelName" : "BE",
     "colorCode" : "#000000",
+    "textColor" : "white"
+  }, {
+    "labelName" : "Lucid",
+    "colorCode" : "#008672",
     "textColor" : "white"
   } ],
   "milestoneInformation" : {
@@ -1442,10 +1450,10 @@ Content-Length: 946
       "imageUrl" : "image1"
     },
     "content" : "contents",
-    "writtenTime" : "2022-07-17T14:48:29.460597",
+    "writtenTime" : "2022-07-18T20:34:26.629172",
     "editable" : true
   } ],
-  "imageUrls" : [ "image3", "image1", "image2" ],
+  "imageUrls" : [ "image2", "image1", "image3" ],
   "open" : true
 }</code></pre>
 </div>
@@ -1952,7 +1960,7 @@ Content-Length: 687
   "milestoneSingleInfos" : [ {
     "id" : null,
     "name" : "m1",
-    "dueDate" : "2022-07-17T14:48:30.367816",
+    "dueDate" : "2022-07-18T20:34:27.617365",
     "description" : "m1 입니다.",
     "openIssueCount" : 0,
     "closeIssueCount" : 0,
@@ -1960,7 +1968,7 @@ Content-Length: 687
   }, {
     "id" : null,
     "name" : "m2",
-    "dueDate" : "2022-07-17T14:48:30.367884",
+    "dueDate" : "2022-07-18T20:34:27.617398",
     "description" : "m2 입니다.",
     "openIssueCount" : 0,
     "closeIssueCount" : 0,
@@ -1968,7 +1976,7 @@ Content-Length: 687
   }, {
     "id" : null,
     "name" : "m3",
-    "dueDate" : "2022-07-17T14:48:30.367893",
+    "dueDate" : "2022-07-18T20:34:27.617405",
     "description" : "m3 입니다.",
     "openIssueCount" : 0,
     "closeIssueCount" : 0,
@@ -2055,12 +2063,12 @@ Content-Length: 687
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer testToken
 Accept: */*
-Content-Length: 115
+Content-Length: 112
 Host: localhost:8080
 
 {
   "name" : "milestone1",
-  "dueDate" : "2022-07-17T14:48:30.421561",
+  "dueDate" : "2022-07-18T20:34:27.664",
   "description" : "마일스톤입니다."
 }</code></pre>
 </div>
@@ -2124,7 +2132,7 @@ Host: localhost:8080
 
 {
   "name" : "milestone1",
-  "dueDate" : "2022-07-17T14:48:30.488119",
+  "dueDate" : "2022-07-18T20:34:27.723804",
   "description" : "마일스톤입니다."
 }</code></pre>
 </div>
@@ -2715,7 +2723,7 @@ Content-Length: 214
     "imageUrl" : "image1"
   },
   "content" : "issue에 작성된 comments 입니다..",
-  "writtenTime" : "2022-07-17T14:48:30.078362",
+  "writtenTime" : "2022-07-18T20:34:27.337991",
   "editable" : true
 }</code></pre>
 </div>
@@ -2891,7 +2899,7 @@ Host: localhost:8080</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-07-17 14:43:39 +0900
+Last updated 2022-07-17 14:52:28 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">


### PR DESCRIPTION
📃 Description
- 쿼리 최적화를 위한 응답 시간 측정을 위해 AOP(Stopwatch) 추가
- 실행 계획 확인 시 issue 조회 쿼리가 적절한 인덱스를 타고 있다고 생각되어 인덱스 학습만 진행
- DB 테이블에 attached_label에 대한 unique 제약조건(issue_id, label_id) 추가
- 페이징,  PageableDefault를 통해 batchSize = 100일 때 기본 10개만 batch query가 날아가도록 해서 성능 개선
